### PR TITLE
Namespaced logger that Adam said he would like

### DIFF
--- a/public/WBLogger.js
+++ b/public/WBLogger.js
@@ -11,11 +11,10 @@ var WBLoggerPrototype = {
 
     var self = this;
 
-    // assert(self.constructor !== WBLogger, 'can\'t initialize WBLogger');
-    assert.string(namespace, 'WBLogger namespace must be a string');
+    assert.string(namespace, 'namespace must be a string');
 
-    var namespaceMap = WBLogger.namespaces;
     // if a cached namespaced logger already exists, simply return it
+    var namespaceMap = WBLogger.namespaces;
     if (namespaceMap[namespace] instanceof WBLogger) {
       return namespaceMap[namespace];
     }
@@ -55,6 +54,7 @@ WBLogger.release = function () {
 
 WBLogger.log = function (regexPatternString) {
 
+  assert.string(regexPatternString, 'regexPatternString must be a string');
   regexPatternString = regexPatternString === '*' ? '.?' : regexPatternString;
   WBLogger.pattern = new RegExp(regexPatternString);
 };

--- a/tests/WBLogger.spec.js
+++ b/tests/WBLogger.spec.js
@@ -4,9 +4,12 @@ describe('WBLogger', function () {
 
   var WBLogger = require('WBLogger');
 
+  var notStrings = [0, undefined, null, /foo|bar/, function () {}, {}];
+
   afterEach(function () {
 
     WBLogger.release();
+    WBLogger.pattern = undefined;
   });
 
   describe('constructor', function () {
@@ -19,6 +22,113 @@ describe('WBLogger', function () {
 
       expect(logger1).to.equal(logger2);
       expect(logger1).to.not.equal(logger3);
+    });
+
+    it ('should throw if namespace is not a string', function () {
+
+      notStrings.forEach(function (namespace) {
+
+        expect(function () {
+
+          new WBLogger(namespace);
+        }).to.throw();
+      });
+    });
+
+    it ('should not throw if namespace is a string', function () {
+
+      expect(function () {
+
+        new WBLogger('test');
+      }).to.not.throw('namespace must be a string');
+    });
+  });
+
+  describe('.log', function () {
+
+    it ('should throw if regexPatternString is not a string', function () {
+
+      notStrings.forEach(function (notAString) {
+
+        expect(function () {
+
+          WBLogger.log(notAString);
+        }).to.throw('regexPatternString must be a string');
+      });
+    });
+
+    it ('should set WBLogger.pattern to a regular expression object', function () {
+
+      var patternString = 'foo|bar';
+      var expectedToString = '/foo|bar/';
+
+      WBLogger.log(patternString);
+      expect(WBLogger.pattern).to.be.instanceOf(RegExp);
+      expect(WBLogger.pattern.toString()).to.equal(expectedToString);
+    });
+
+    it ('should convert \'*\' to an all string matching regex pattern', function () {
+
+      var patternString = '*';
+      var expectedToString = '/.?/';
+
+      WBLogger.log(patternString);
+      expect(WBLogger.pattern).to.be.instanceOf(RegExp);
+      expect(WBLogger.pattern.toString()).to.equal(expectedToString);
+    });
+  });
+
+  describe('#shouldRun', function () {
+
+    it ('should return false if WBLogger.pattern is undefined', function () {
+
+      var logger = new WBLogger('test');
+      WBLogger.pattern = undefined;
+      expect(logger.shouldRun()).to.be.false;
+    });
+
+    it ('should return true if WBLogger.pattern matches instance namespace', function () {
+
+      var logger = new WBLogger('test');
+      WBLogger.log('test');
+      expect(logger.shouldRun()).to.be.true;
+    });
+
+    it ('should return false if WBLogger.pattern does not match instance namespace', function () {
+
+      var logger = new WBLogger('test');
+      WBLogger.log('foo');
+      expect(logger.shouldRun()).to.be.false;
+    });
+  });
+
+  describe('Instance Integration Tests', function () {
+
+    describe('#log', function () {
+
+      it ('should run if WBLogger is setup for the instance namespace', function () {
+
+        var logSpy = sinon.spy(console, 'log');
+        var logger = new WBLogger('test');
+        WBLogger.log('test');
+
+        logger.log('foobar');
+
+        expect(logSpy).to.have.been.calledOnce;
+        logSpy.restore();
+      });
+
+      it ('should not run if WBLogger is not setup for the instance namespace', function () {
+
+        var logSpy = sinon.spy(console, 'log');
+        var logger = new WBLogger('test');
+        WBLogger.log('foo');
+
+        logger.log('foobar');
+
+        expect(logSpy).to.not.have.been.calledOnce;
+        logSpy.restore();
+      });
     });
   });
 });


### PR DESCRIPTION
will write more tests, but this already works

``` javascript
WBLogger.log('io');
var ioLogger = new WBLogger('io');
var schemaLogger = new WBlogger('schema');

ioLogger.log('foobar');
```

> foobar

``` javascript
schemaLogger.dir(someSchema); // (does nothing since log patter 'io' does not match 'schema')
```

Namespaced instances are cached a la the WL WBCollection.
# 
- [x] move to own node module
- [ ] support env varialbes for setting log pattern (for node)
- [ ] colors via @netroy 
- [ ] loglevel support? (this would be a second conditional on the console method - not the namespace)
